### PR TITLE
Fix to issue when deserialize opening_hours of place details

### DIFF
--- a/GoogleMapsAPI.NET.Core/API/Places/Components/PlaceOpeningPeriodDayTime.cs
+++ b/GoogleMapsAPI.NET.Core/API/Places/Components/PlaceOpeningPeriodDayTime.cs
@@ -22,7 +22,7 @@ namespace GoogleMapsAPI.NET.API.Places.Components
         /// time will be reported in the place’s time zone.
         /// </summary>
         [DataMember(Name = "time")]
-        public int Time { get; set; }
+        public string Time { get; set; }
 
         #endregion
         

--- a/GoogleMapsAPI.NET.Core/API/Places/Components/PlaceOpeningPeriods.cs
+++ b/GoogleMapsAPI.NET.Core/API/Places/Components/PlaceOpeningPeriods.cs
@@ -16,13 +16,13 @@ namespace GoogleMapsAPI.NET.API.Places.Components
         /// When the place opens
         /// </summary>
         [DataMember(Name = "open")]
-        public List<PlaceOpeningPeriodDayTime> Open { get; set; }
+        public PlaceOpeningPeriodDayTime Open { get; set; }
 
         /// <summary>
         /// When the place closes
         /// </summary>
         [DataMember(Name = "close")]
-        public List<PlaceOpeningPeriodDayTime> Close { get; set; }
+        public PlaceOpeningPeriodDayTime Close { get; set; }
 
         #endregion
 


### PR DESCRIPTION
Good afternoon, make a small change to your library because it was throwing me an error when deserializar the answer obtained by the method PlaceDetail, because I was waiting for an arrangement instead of an object. Please integrate this little fix. I liked your work with this library so I wanted to contribute with this fix.