### PR TITLE
Supermarket support

### DIFF
--- a/GoogleMapsAPI.NET.Core/API/Places/Enums/PlaceResultTypeEnum.cs
+++ b/GoogleMapsAPI.NET.Core/API/Places/Enums/PlaceResultTypeEnum.cs
@@ -454,7 +454,7 @@ namespace GoogleMapsAPI.NET.API.Places.Enums
         [EnumMember(Value = "subway_station")]
         SubwayStation,
         /// <summary>
-        /// Subway station
+        /// Supermarket
         /// </summary>
         [EnumMember(Value = "supermarket")]
         Supermarket,

--- a/GoogleMapsAPI.NET.Core/API/Places/Enums/PlaceResultTypeEnum.cs
+++ b/GoogleMapsAPI.NET.Core/API/Places/Enums/PlaceResultTypeEnum.cs
@@ -454,6 +454,11 @@ namespace GoogleMapsAPI.NET.API.Places.Enums
         [EnumMember(Value = "subway_station")]
         SubwayStation,
         /// <summary>
+        /// Subway station
+        /// </summary>
+        [EnumMember(Value = "supermarket")]
+        Supermarket,
+        /// <summary>
         /// Synagogue
         /// </summary>
         [EnumMember(Value = "synagogue")]


### PR DESCRIPTION
Support for the supermarket type. 

You can see an example using the google places id "54d166379ef22478fe4c44d787bf4f0f88776ad3" the resultant types array is 

` "types" : [
            "supermarket",
            "grocery_or_supermarket",
            "food",
            "store",
            "point_of_interest",
            "establishment"
],`

